### PR TITLE
Do not specify parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  parser  : 'babel-eslint',
   extends : [
     'xo-space'
   ],


### PR DESCRIPTION
`parser` は上書きできないようなので、こちらでは未指定にしてプロジェクト側で明示してもらう。
これで [`babel/babel-eslint`](https://github.com/babel/babel-eslint) も [`eslint/typescript-eslint-parser`](https://github.com/eslint/typescript-eslint-parser) も使える。